### PR TITLE
ISSUE#SB-19521: added new env vars(private container) for certificate generation 

### DIFF
--- a/src/envVariables.js
+++ b/src/envVariables.js
@@ -6,6 +6,11 @@ const envVariables = {
   azureAccountName: process.env.sunbird_azure_account_name,
   azureAccountKey: process.env.sunbird_azure_account_key,
   azureContainerName: process.env.sunbird_azure_container_name,
+  privateContainer: {
+    azureAccountName: process.env.sunbird_pvt_azure_account_name,
+    azureAccountKey: process.env.sunbird_pvt_azure_account_key,
+    azureContainerName: process.env.sunbird_pvt_azure_container_name
+  },
   level: process.env.service_log_level || 'info',
   encodingType: process.env.service_encoding_type,
   filename: process.env.service_file_filename || 'print-service-%DATE%.log',


### PR DESCRIPTION
New env vars for certificate generation.

`sunbird_pvt_azure_account_name`
`sunbird_pvt_azure_account_key`
`sunbird_pvt_azure_container_name`

- Print-service uses both private and public container. Generated certificates (v1/print/pdf) are uploaded to the private container is used. "/print/preview/generate" API uses public container.

- In this PR https://github.com/project-sunbird/sunbird-devops/pull/1387 env vars for "/print/preview/generate" api is overridden by a private container vars which caused the issue https://project-sunbird.atlassian.net/browse/SB-19521